### PR TITLE
Minor fixes frontend deployment

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -69,6 +69,11 @@
             <artifactId>spring-security-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>de.neuefische.java</groupId>
+            <artifactId>spring-boot-starter-fallback-page</artifactId>
+            <version>1.0.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -8,7 +8,7 @@
         <version>3.5.5</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
-    <groupId>org.example</groupId>
+    <groupId>de.floralbite</groupId>
     <artifactId>backend</artifactId>
     <version>0.0.1-SNAPSHOT</version>
     <name>backend</name>

--- a/backend/src/main/java/de/floralbite/backend/BackendApplication.java
+++ b/backend/src/main/java/de/floralbite/backend/BackendApplication.java
@@ -1,4 +1,4 @@
-package org.example.backend;
+package de.floralbite.backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;

--- a/backend/src/main/java/de/floralbite/backend/security/AdminUser.java
+++ b/backend/src/main/java/de/floralbite/backend/security/AdminUser.java
@@ -1,4 +1,4 @@
-package org.example.backend.security;
+package de.floralbite.backend.security;
 
 import lombok.Builder;
 import org.springframework.data.annotation.Id;

--- a/backend/src/main/java/de/floralbite/backend/security/AdminUserRepo.java
+++ b/backend/src/main/java/de/floralbite/backend/security/AdminUserRepo.java
@@ -1,4 +1,4 @@
-package org.example.backend.security;
+package de.floralbite.backend.security;
 
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Repository;

--- a/backend/src/main/java/de/floralbite/backend/security/AuthController.java
+++ b/backend/src/main/java/de/floralbite/backend/security/AuthController.java
@@ -1,4 +1,4 @@
-package org.example.backend.security;
+package de.floralbite.backend.security;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -8,8 +8,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
-
-import java.util.Objects;
 
 @RestController
 @RequestMapping("/api/auth")

--- a/backend/src/main/java/de/floralbite/backend/security/CustomOidcUserService.java
+++ b/backend/src/main/java/de/floralbite/backend/security/CustomOidcUserService.java
@@ -1,4 +1,4 @@
-package org.example.backend.security;
+package de.floralbite.backend.security;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;

--- a/backend/src/main/java/de/floralbite/backend/security/SecurityConfig.java
+++ b/backend/src/main/java/de/floralbite/backend/security/SecurityConfig.java
@@ -1,4 +1,4 @@
-package org.example.backend.security;
+package de.floralbite.backend.security;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;

--- a/backend/src/test/java/de/floralbite/backend/BackendApplicationTests.java
+++ b/backend/src/test/java/de/floralbite/backend/BackendApplicationTests.java
@@ -1,4 +1,4 @@
-package org.example.backend;
+package de.floralbite.backend;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;

--- a/backend/src/test/java/de/floralbite/backend/security/AuthControllerTest.java
+++ b/backend/src/test/java/de/floralbite/backend/security/AuthControllerTest.java
@@ -1,4 +1,4 @@
-package org.example.backend.security;
+package de.floralbite.backend.security;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/backend/src/test/java/de/floralbite/backend/security/CustomOidcUserServiceTest.java
+++ b/backend/src/test/java/de/floralbite/backend/security/CustomOidcUserServiceTest.java
@@ -1,4 +1,4 @@
-package org.example.backend.security;
+package de.floralbite.backend.security;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -5,34 +5,6 @@
   text-align: center;
 }
 
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
-}
-
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
-  }
-}
-
 .card {
   padding: 2em;
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -14,12 +14,11 @@
 }
 
 a {
-  font-weight: 500;
-  color: #646cff;
+  color: #CA6263; /* war vorher: #646cff */
   text-decoration: inherit;
 }
 a:hover {
-  color: #747bff;
+  color: #da8888; /* war vorher: #747bff */
 }
 
 body {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3,9 +3,9 @@
   line-height: 1.5;
   font-weight: 400;
 
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
+  color-scheme: light; /* Nur Lightmode */
+  color: #213547;
+  background-color: #ffffff;
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
@@ -19,7 +19,7 @@ a {
   text-decoration: inherit;
 }
 a:hover {
-  color: #535bf2;
+  color: #747bff;
 }
 
 body {
@@ -42,7 +42,7 @@ button {
   font-size: 1em;
   font-weight: 500;
   font-family: inherit;
-  background-color: #1a1a1a;
+  background-color: #f9f9f9;
   cursor: pointer;
   transition: border-color 0.25s;
 }
@@ -52,17 +52,4 @@ button:hover {
 button:focus,
 button:focus-visible {
   outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
 }

--- a/frontend/src/pages/PlaceholderPage.tsx
+++ b/frontend/src/pages/PlaceholderPage.tsx
@@ -5,7 +5,9 @@ export default function PlaceholderPage() {
             <img src={"/assets/placeholderLogo.png"} alt={"Vorläufiges Logo von Floral Bite"} className={"placeholder"}/>
             <img src={"/assets/placeholderTitle.png"} alt={"Vorläufiger Schriftzug von Floral Bite"} className={"placeholder"} width={"50%"}/>
             <h1 className={"placeholder"}>Herzlich Willkommen bei Floral Bite!</h1>
-            <h2 className={"placeholder"}>Diese Website befindet sich noch im Aufbau. Bitte wenden Sie sich für Anfragen an Julia Schreck.</h2>
+            <h2 className={"placeholder"}>Diese Website befindet sich noch im Aufbau. Bitte wenden Sie sich für Anfragen an Julia Schreck:{" "}
+                <a href="mailto:anfrage@floralbite.de">anfrage@floralbite.de</a>
+            </h2>
         </div>
     );
 }


### PR DESCRIPTION
- added mail adress to placeholder page
  - added some styling
- set light-mode as default and removed dark-mode entirely 
- refactored project-folders from org.example to de.floralbite
- added dependency to add a fallback page for direct access to url-paths, like floralbite.de/login or floralbite.de/admin

<img width="1918" height="1036" alt="PR_bild003" src="https://github.com/user-attachments/assets/6dd87a8f-099a-4940-b257-aa9a3da19309" />