### PR TITLE
Verbesserte Effekte bei den Angebotskarten

### DIFF
--- a/frontend/src/components/OfferCard.tsx
+++ b/frontend/src/components/OfferCard.tsx
@@ -23,81 +23,66 @@ export default function OfferCard(props: Readonly<OfferCardProps>) {
     }
     const imageUrl = "/assets/" + props.type + ".webp";
 
-    /* Aufbau in eine äußere und eine innere Box, damit ein 3D-Effekt möglich ist.
-    * perspective: "2000px" bedeutet, dass die "Kamera" für den 3D-Effekt 2000px vom Geschehen entfernt wirkt. Dadurch
-    * wirkt es natürlicher und sanfter, als bei einem kleineren Wert.
-    * boxSizing: "border-box" ist nötig, damit das spacing vom übergeordneten Grid noch funktioniert. */
     return (
         <Box
             sx={{
-                perspective: "2000px",
+                position: "relative",
                 width: "100%",
                 aspectRatio: "1 / 1",
                 boxSizing: "border-box",
+                borderRadius: "0.4rem",
+                overflow: "hidden",
+                '&:hover .front': {
+                    opacity: 0,
+                },
+                '&:hover .back': {
+                    opacity: 1,
+                },
             }}
         >
-            {/* Die innere Box, die die Transformation durchführt. Wenn man mit der Maus über die Karte hovert, wird
-             sie umgedreht. */}
+            {/* Vorderseite */}
             <Box
+                className="front"
                 sx={{
-                    position: "relative",
+                    position: "absolute",
                     width: "100%",
                     height: "100%",
-                    transition: "transform 1s",
-                    transformStyle: "preserve-3d",
+                    backgroundColor: "var(--light-sage-green)",
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
                     borderRadius: "0.4rem",
-                    '&:hover': {
-                        transform: "rotateY(180deg)",
-                    },
+                    transition: "opacity 0.5s ease-in-out",
+                    opacity: 1,
+                    zIndex: 2,
                 }}
             >
-                {/* Vorderseite der Karte, die den Titel zeigt. */}
-                <Box
-                    sx={{
-                        position: "absolute",
+                <h3 style={{ margin: 0, padding: "0 8px", textAlign: "center" }}>{title}</h3>
+            </Box>
+
+            {/* Rückseite */}
+            <Box
+                className="back"
+                sx={{
+                    position: "absolute",
+                    width: "100%",
+                    height: "100%",
+                    opacity: 0,
+                    transition: "opacity 0.5s ease-in-out",
+                    zIndex: 1,
+                }}
+            >
+                <img
+                    src={imageUrl}
+                    alt={`Eine Speise der Kategorie ${title}`}
+                    style={{
                         width: "100%",
                         height: "100%",
-                        backfaceVisibility: "hidden",
+                        objectFit: "cover",
                         borderRadius: "0.4rem",
-                        backgroundColor: "var(--light-sage-green)",
-                        display: "flex",
-                        alignItems: "center",
-                        justifyContent: "center",
-                        overflow: "hidden",
-                        boxSizing: "border-box",
+                        display: "block",
                     }}
-                >
-                    {/* Padding muss direkt in den h3-Tag, da es sonst zu Verzerrungen und Verschiebungen kommt. */}
-                    <h3 style={{ margin: 0, padding: "0 8px", textAlign: "center" }}>{title}</h3>
-                </Box>
-                {/* Rückseite der Karte, die ein Bild zeigt. */}
-                <Box
-                    sx={{
-                        position: "absolute",
-                        width: "100%",
-                        height: "100%",
-                        backfaceVisibility: "hidden",
-                        transform: "rotateY(180deg)",
-                        display: "flex",
-                        alignItems: "center",
-                        justifyContent: "center",
-                        borderRadius: "0.4rem",
-                        overflow: "hidden",
-                        boxSizing: "border-box",
-                    }}
-                >
-                    <img
-                        src={imageUrl}
-                        alt={`Eine Speise der Kategorie ${title}`}
-                        style={{
-                            width: "100%",
-                            height: "100%",
-                            objectFit: "cover",
-                            borderRadius: "0.4rem",
-                            display: "block",
-                        }}
-                    />
-                </Box>
+                />
             </Box>
         </Box>
     )

--- a/frontend/src/components/OfferCard.tsx
+++ b/frontend/src/components/OfferCard.tsx
@@ -1,5 +1,7 @@
 import type {OfferCategory} from "../models/OfferCategory.ts";
 import {Box} from "@mui/material";
+import {useIsTouchDevice} from "../utils/useIsTouchDevice.ts";
+import {useState} from "react";
 
 type OfferCardProps = {
     type: OfferCategory;
@@ -23,8 +25,21 @@ export default function OfferCard(props: Readonly<OfferCardProps>) {
     }
     const imageUrl = "/assets/" + props.type + ".webp";
 
+    // Abfrage, ob das Gerät ein Touch- oder Mausgerät ist:
+    const isTouchDevice = useIsTouchDevice();
+    // Zustand der Karte:
+    const [flipped, setFlipped] = useState(false);
+    // Bei Touch-Geräten, soll ein Click die Karte umdrehen:
+    const handleClick = () => {
+        if (isTouchDevice) {
+            setFlipped((prev) => !prev);
+        }
+    };
+
     return (
         <Box
+            // Bei Touch-Geräten ist klicken möglich:
+            onClick={handleClick}
             sx={{
                 position: "relative",
                 width: "100%",
@@ -32,11 +47,12 @@ export default function OfferCard(props: Readonly<OfferCardProps>) {
                 boxSizing: "border-box",
                 borderRadius: "0.4rem",
                 overflow: "hidden",
+                // Hover-Effekt nur bei Maus-Geräten. Überschreibt die opacity, die durch "flipped" angegeben wird:
                 '&:hover .front': {
-                    opacity: 0,
+                    opacity: isTouchDevice ? undefined : 0,
                 },
                 '&:hover .back': {
-                    opacity: 1,
+                    opacity: isTouchDevice ? undefined : 1,
                 },
             }}
         >
@@ -52,9 +68,10 @@ export default function OfferCard(props: Readonly<OfferCardProps>) {
                     alignItems: "center",
                     justifyContent: "center",
                     borderRadius: "0.4rem",
-                    transition: "opacity 0.5s ease-in-out",
-                    opacity: 1,
-                    zIndex: 2,
+                    transition: "opacity 0.4s ease-in-out",
+                    // Opacity und z-Position kann auch durch Anklicken auf einem Smartphone geändert werden
+                    opacity: flipped ? 0 : 1,
+                    zIndex: flipped ? 1 : 2,
                 }}
             >
                 <h3 style={{ margin: 0, padding: "0 8px", textAlign: "center" }}>{title}</h3>
@@ -67,9 +84,10 @@ export default function OfferCard(props: Readonly<OfferCardProps>) {
                     position: "absolute",
                     width: "100%",
                     height: "100%",
-                    opacity: 0,
-                    transition: "opacity 0.5s ease-in-out",
-                    zIndex: 1,
+                    transition: "opacity 0.4s ease-in-out",
+                    // Opacity und z-Position kann auch durch Anklicken auf einem Smartphone geändert werden
+                    opacity: flipped ? 1 : 0,
+                    zIndex: flipped ? 2 : 1,
                 }}
             >
                 <img

--- a/frontend/src/utils/checkIfTouchDevice.ts
+++ b/frontend/src/utils/checkIfTouchDevice.ts
@@ -1,0 +1,19 @@
+import {useEffect, useState} from "react";
+
+export default function CheckIfTouchDevice() {
+    const [isTouchDevice, setIsTouchDevice] = useState(false);
+
+    useEffect(() => {
+        const checkTouch = () => {
+            // MediaQuery, ob das Gerät über Maus-Hover verfügt oder nicht
+            setIsTouchDevice(window.matchMedia('(hover:none)').matches);
+        };
+        // Beim Start
+        checkTouch();
+        // Erneute Abfrage bei Fenstergrößenänderung, relevant für Hybridgeräte
+        window.addEventListener('resize', checkTouch);
+        return () => window.removeEventListener('resize', checkTouch);
+    }, []);
+
+    return isTouchDevice;
+}

--- a/frontend/src/utils/useIsTouchDevice.ts
+++ b/frontend/src/utils/useIsTouchDevice.ts
@@ -1,12 +1,14 @@
 import {useEffect, useState} from "react";
 
-export default function CheckIfTouchDevice() {
+// Der Name muss "use" am Anfang haben, damit React es als Hook erkennt.
+// Hooks sind spezielle Funktionen von React mit denen man auf Zustand, Lifecycle, Context etc. zugreifen kann.
+export function useIsTouchDevice() {
     const [isTouchDevice, setIsTouchDevice] = useState(false);
 
     useEffect(() => {
         const checkTouch = () => {
             // MediaQuery, ob das Gerät über Maus-Hover verfügt oder nicht
-            setIsTouchDevice(window.matchMedia('(hover:none)').matches);
+            setIsTouchDevice(window.matchMedia('(hover: none)').matches);
         };
         // Beim Start
         checkTouch();

--- a/frontend/src/utils/useIsTouchDevice.ts
+++ b/frontend/src/utils/useIsTouchDevice.ts
@@ -8,6 +8,7 @@ export function useIsTouchDevice() {
     useEffect(() => {
         const checkTouch = () => {
             // MediaQuery, ob das Gerät über Maus-Hover verfügt oder nicht
+            // window.matchMedia ist eine Abfrage an die Browser-API
             setIsTouchDevice(window.matchMedia('(hover: none)').matches);
         };
         // Beim Start


### PR DESCRIPTION
- Beim Umdrehen der Angebotskarten Fading-Effekt statt Flipping
- MediaQuery ob Touch- oder Maus-Gerät
- Touch-Geräte drehen die Karten mit Antippen statt Hovern