### PR TITLE
Logik für Mobile Ansichten

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -35,7 +35,7 @@ main {
     font-size: 1.125rem; /* 1.125 */
   }
   main {
-    padding: 1.5rem;
+    padding: 4.5rem 1.5rem 1.5rem;
   }
 }
 img.placeholderLogo {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -224,6 +224,13 @@ button.scrollButton {
     display: none;
   }
 }
+@media (max-width: 600px) {
+  button.scrollButton {
+    width: 2.5rem;
+    height: 2.5rem;
+    font-size: 1.8rem;
+  }
+}
 button.scrollButton:hover {
   border-color: rgb(var(--link-color));
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,7 +14,7 @@ import PlaceholderPage from "./pages/PlaceholderPage.tsx";
 import GalleryPage from "./pages/GalleryPage.tsx";
 import Header from './components/Header.tsx';
 import OfferPage from "./pages/OfferPage.tsx";
-import PricesPage from "./pages/PricesPage.tsx";
+import PricePage from "./pages/PricePage.tsx";
 import AboutUsPage from "./pages/AboutUsPage.tsx";
 import ContactPage from "./pages/ContactPage.tsx";
 import HomePage from "./pages/HomePage.tsx";
@@ -73,7 +73,7 @@ function App() {
                 <Route element={<ProtectedRoute user={user} />}>
                     <Route path="/home" element={<HomePage />} />
                     <Route path="/angebot" element={<OfferPage />} />
-                    <Route path="/preise" element={<PricesPage />} />
+                    <Route path="/preise" element={<PricePage />} />
                     <Route path="/ueber-uns" element={<AboutUsPage />} />
                     <Route path="/galerie" element={<GalleryPage />} />
                     <Route path="/kontakt" element={<ContactPage />} />

--- a/frontend/src/components/MobileHeader.tsx
+++ b/frontend/src/components/MobileHeader.tsx
@@ -12,7 +12,7 @@ export default function MobileHeader() {
     }
 
     return (
-        <AppBar position="sticky" sx={{ backgroundColor: 'white', top: 0 }}>
+        <AppBar position="fixed" sx={{ backgroundColor: 'white', top: 0 }}>
             <Toolbar sx={{ position: 'relative', minHeight: '3rem'}}>
                 <IconButton
                     edge="start"

--- a/frontend/src/components/MobileHeader.tsx
+++ b/frontend/src/components/MobileHeader.tsx
@@ -35,7 +35,8 @@ export default function MobileHeader() {
             </Toolbar>
             {menuOpen ?
                 <Stack sx={{ width: '100%', color: 'var(--dark-green)', '& a': {color: 'var(--dark-green) !important'},
-                    padding: '1rem', borderTop: '1px solid var(--light-sage-green)'}}>
+                    padding: '1rem', borderTop: '1px solid var(--light-sage-green)'}} onClick={
+                    () => setMenuOpen(false)}>
                     <Link to={"/home"}>Home</Link>
                     <Link to={"/angebot"}>Angebot</Link>
                     <Link to={"/ueber-uns"}>Über uns</Link>

--- a/frontend/src/components/OfferCard.tsx
+++ b/frontend/src/components/OfferCard.tsx
@@ -1,7 +1,7 @@
 import {type OfferCategory, offerCategoryTitles} from "../models/OfferCategory.ts";
 import {Box} from "@mui/material";
 import {useIsTouchDevice} from "../utils/useIsTouchDevice.ts";
-import {useState} from "react";
+import {useState, type MouseEvent} from "react";
 
 type OfferCardProps = {
     type: OfferCategory;
@@ -27,6 +27,12 @@ export default function OfferCard(props: Readonly<OfferCardProps>) {
             props.select(props.type);
         }
     };
+    const handleMobileClick = (event: MouseEvent) => {
+        // Verhindert, das zu dem handleMobileClick der inneren Box zusätzlich noch das handleClick der äußeren Box
+        // aufgerufen wird.
+        event.stopPropagation();
+        props.select(props.type);
+    }
 
     return (
         <Box
@@ -77,6 +83,7 @@ export default function OfferCard(props: Readonly<OfferCardProps>) {
                     position: "absolute",
                     width: "100%",
                     height: "100%",
+                    backgroundColor: "var(--light-sage-green)",
                     transition: "opacity 0.4s ease-in-out",
                     // Opacity und z-Position kann auch durch Anklicken auf einem Smartphone geändert werden
                     opacity: flipped ? 1 : 0,
@@ -88,12 +95,15 @@ export default function OfferCard(props: Readonly<OfferCardProps>) {
                     alt={`Eine Speise der Kategorie ${title}`}
                     style={{
                         width: "100%",
-                        height: "100%",
+                        height: isTouchDevice ? "77%" : "100%",
                         objectFit: "cover",
-                        borderRadius: "0.4rem",
                         display: "block",
                     }}
                 />
+                {isTouchDevice ? <Box sx={{display: "flex", justifyContent: "center", height: "23%", alignItems: "center"}}
+                    onClick={handleMobileClick}>
+                    <p style={{margin: 0, fontWeight: 600}}>Mehr Infos?</p>
+                </Box> : null}
             </Box>
         </Box>
     )

--- a/frontend/src/components/OfferDetail.tsx
+++ b/frontend/src/components/OfferDetail.tsx
@@ -23,7 +23,7 @@ export default function OfferDetail(props: Readonly<OfferDetailProps>) {
             für ein individuelles Angebot nach deinen Wünschen. Ich freue mich, von dir zu hören.</p>
             {/* Button-Komponente vom Typ Link ist besser für die Barrierefreiheit als Buttons und Links zu
             verschachteln. */}
-            <Stack spacing={2} direction="row">
+            <Stack spacing={3} direction="row" sx={{py: 1.5}}>
                 <button className={"contactForm"}>
                     <Link to={"/preise"}>Angebotsübersicht</Link>
                 </button>

--- a/frontend/src/pages/OfferPage.tsx
+++ b/frontend/src/pages/OfferPage.tsx
@@ -1,7 +1,7 @@
 import OfferCard from "../components/OfferCard.tsx";
 import OfferDetail from "../components/OfferDetail.tsx";
 import {Grid} from "@mui/material";
-import {useState} from "react";
+import {useEffect, useRef, useState} from "react";
 import DesignBar from "../components/DesignBar.tsx";
 import {offerCategories, type OfferCategory} from "../models/OfferCategory.ts";
 
@@ -9,11 +9,23 @@ export default function OfferPage() {
 
     const [selected, setSelected] = useState<OfferCategory | undefined>(undefined);
 
+    // Referenzpunkt für flexibles Scrollen zur Detailansicht
+    const detailRef = useRef<HTMLDivElement>(null);
+    // Jedes Mal, wenn die Detailansicht geöffnet wird, springt die Ansicht hoch zur Detailansicht
+    useEffect(() => {
+        if (selected !== undefined) {
+            detailRef.current?.scrollIntoView({ behavior: 'smooth' });
+        }
+    }, [selected]);
+
     return (
         <>
             {selected === undefined ? <h2>Das Angebot von FloralBite</h2>
                 : <>
-                    <OfferDetail type={selected}/>
+                    {/* Referenzpunkt für das Scrollen zur Detailansicht */}
+                    <div ref={detailRef}>
+                        <OfferDetail type={selected}/>
+                    </div>
                     <DesignBar/>
                     <h2>Weitere Angebote</h2>
                 </>}

--- a/frontend/src/pages/PricePage.tsx
+++ b/frontend/src/pages/PricePage.tsx
@@ -4,15 +4,17 @@ import PriceList from "../components/PriceList.tsx";
 import DesignBar from "../components/DesignBar.tsx";
 import {Box} from "@mui/material";
 
-export default function PricesPage() {
+export default function PricePage() {
     return (
         <>
             <h2>Angebote und Preise</h2>
-            <p>Hier findest du unsere aktuellen Angebote und Preise. Für individuelle Angebote, kannst du dich auch
+            <p>Hier findest du die aktuellen Angebote und Preise. Für individuelle Angebote, kannst du dich auch
                 gerne bei mir melden:</p>
-            <button className={"contactForm"}>
-                <Link to={"/kontakt"}>Individuelle Anfrage</Link>
-            </button>
+            <Box sx={{textAlign: "center", paddingBottom: 1}}>
+                <button className={"contactForm"}>
+                    <Link to={"/kontakt"}>Individuelle Anfrage</Link>
+                </button>
+            </Box>
             <DesignBar/>
             {offerCategories.map((cat) => <PriceList type={cat}/>)}
             <Box sx={{textAlign: "center", py: {xs: '4%', sm: '3%'}}}>

--- a/frontend/src/utils/useIsTouchDevice.ts
+++ b/frontend/src/utils/useIsTouchDevice.ts
@@ -13,11 +13,11 @@ export function useIsTouchDevice() {
             // TouchPoints: 0 kein Touchgerät, 1 einfaches Touchgerät, 5 oder 10 Multitouch wie Smartphone oder Tablet
             // window.matchMedia('(hover: none)').matches ist eine MediaQuery an die Browser-API über Hover-Fähigkeit
             // pointer gibt coarse bei smartphones und tablets an, allerdings auch bei manchen Hybridgeräten
-            // innerWidth < xxx ist dabei, weil Chrome auf Android gerne falsche Dinge meldet
+            // innerWidth < xxx ist optional dabei, weil Chrome auf Android gerne falsche Dinge meldet
             // innerWidth < 850 oder 600 je nachdem wie man Smartphones im Querformat werten möchte.
             const hasTouchSupport =
                 ('ontouchstart' in window || navigator.maxTouchPoints > 0) &&
-                (window.matchMedia('(pointer: coarse)').matches || window.innerWidth < 600 || window.matchMedia('(hover: none)').matches);
+                (window.matchMedia('(pointer: coarse)').matches || window.matchMedia('(hover: none)').matches);
             setIsTouchDevice(hasTouchSupport);
         };
         // Beim Start


### PR DESCRIPTION
- Auf Geräten ohne Maus kann jetzt auch die Detailansicht von Angeboten geöffnet werden
- Es wird automatisch zur Detailansicht gescrollt.
- Mobiler Header ist jetzt sticky und Menü schließt sich wieder, wenn es benutzt wurde